### PR TITLE
Made RehostedJarHandler less trigger happy

### DIFF
--- a/src/main/java/moe/plushie/armourers_workshop/client/handler/RehostedJarHandler.java
+++ b/src/main/java/moe/plushie/armourers_workshop/client/handler/RehostedJarHandler.java
@@ -40,7 +40,7 @@ public final class RehostedJarHandler {
             return;
         }
         
-        if (jarFile.getName().equals(originalName)) {
+        if (jarFile.getName().replaceAll("\\(\\d+\\)", "").replaceAll(" ", "").equals(originalName)) {
             // Names match.
             validJar = true;
             return;

--- a/src/main/java/moe/plushie/armourers_workshop/client/handler/RehostedJarHandler.java
+++ b/src/main/java/moe/plushie/armourers_workshop/client/handler/RehostedJarHandler.java
@@ -40,7 +40,7 @@ public final class RehostedJarHandler {
             return;
         }
         
-        if (jarFile.getName().replaceAll("\\(\\d+\\)", "").replaceAll(" ", "").equals(originalName)) {
+        if (jarFile.getName().contains(originalName)) {
             // Names match.
             validJar = true;
             return;

--- a/src/main/java/moe/plushie/armourers_workshop/proxies/ClientProxy.java
+++ b/src/main/java/moe/plushie/armourers_workshop/proxies/ClientProxy.java
@@ -150,7 +150,7 @@ public class ClientProxy extends CommonProxy implements IBakedSkinReceiver {
         ConfigHandlerClient.init(new File(getModConfigDirectory(), "client.cfg"));
 
         enableCrossModSupport();
-        new RehostedJarHandler(event.getSourceFile(), "Armourers-Workshop-" + LibModInfo.MOD_VERSION + ".jar");
+        new RehostedJarHandler(event.getSourceFile(), "Armourers-Workshop-" + LibModInfo.MOD_VERSION);
         new GuiResourceManager();
 
         ReflectionHelper.setPrivateValue(ArmourersWorkshopClientApi.class, null, SkinRenderHandlerApi.INSTANCE, "skinRenderHandler");


### PR DESCRIPTION
This isn't really a bug fix, but I think it may help avoid unnecessary bug reports.
So as someone who uses this system as well, I have noticed that a lot of people have been reporting getting the warn message, even though they downloaded it of curse. After further investigating I realized that they simply downloaded the same jar file multiple times, causing each new one to get a **(number)** at the end.
![image](https://user-images.githubusercontent.com/36803991/96570299-dd4a5380-12d2-11eb-8644-1493df6985ba.png)
I edited the code slightly so it removes the **(number)** and **whitespace**. I did attempt using the **trim()** method instead of the replace one but it doesn't work. My theory is a new line char gets added to the end, preventing trim from working. But it shouldn't really matter, as the Jar File Name normally does not contain any whitespace.