### PR TITLE
Added support for "Steam and Rails" Conductor skins

### DIFF
--- a/common/src/main/resources/data/armourers_workshop/skin/profiles/conductor.json
+++ b/common/src/main/resources/data/armourers_workshop/skin/profiles/conductor.json
@@ -1,0 +1,13 @@
+{
+  "slots": {
+    "head": "default_mob_slots",
+    "chest": "default_mob_slots",
+    "legs": "default_mob_slots",
+    "feet": "default_mob_slots",
+    "wings": "default_mob_slots",
+    "outfit": "default_mob_slots"
+  },
+  "entities": [
+    "railways:conductor"
+  ]
+}


### PR DESCRIPTION
Steam and Rails is a Create mod addon that adds many features related to trains. One of the features is the Conductor, an entity that can be used to drive trains, be remote cameras, or automatically press buttons.

The goal of this PR is to add skin support to Conductors since this is something I missed while playing. 

